### PR TITLE
fix:Eliminated redundant password hashing

### DIFF
--- a/backend/user/views.py
+++ b/backend/user/views.py
@@ -188,7 +188,6 @@ class UserSignupView(GenericAPIView):
         # 注册
         try:
             data = request.data.copy()
-            data['password'] = make_password(data['password'])
             serializer = UserSerializer(data=data)
             serializer.is_valid(True)
             serializer.save()


### PR DESCRIPTION
Fix: Eliminated redundant password hashing

Previously, the password was being hashed multiple times upon user registration or update, which was unnecessary . Addressed this by ensuring the password is hashed only once before being stored in the database.